### PR TITLE
Trivial fix to compilation error with ruby 1.8.7 patchlevel 253, Snow Leopard (1.6.6)

### DIFF
--- a/ext/i386-darwin/dtrace_probe.c
+++ b/ext/i386-darwin/dtrace_probe.c
@@ -251,7 +251,7 @@ VALUE dtraceprobe_probe_offset(VALUE self, VALUE file_addr, VALUE argc)
   void *probe_addr;
   int offset;
   probe_addr = (void *)FIX2INT(rb_funcall(self, rb_intern("addr"), 0));
-  switch FIX2INT(argc) {
+  switch (FIX2INT(argc)) {
     case 0:
       offset = 40; /* 32 + 6 + 2 */
       break;


### PR DESCRIPTION
This just adds a missing set of parenthesis for this platform-specific file.

As far as I can test it, this fixes http://rubyforge.org/tracker/index.php?func=detail&aid=28215&group_id=4929&atid=19033
